### PR TITLE
Support Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,12 +48,14 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.4']
-        laravel: ['11.*', '12.*']
+        laravel: ['11.*', '12.*', '13.*']
         include:
           - laravel: '11.*'
             testbench: '9.*'
           - laravel: '12.*'
             testbench: '10.*'
+          - laravel: '13.*'
+            testbench: '11.*'
 
     steps:
     - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpstan/phpstan": "^1.0 || ^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0.1",
         "phpstan/phpstan-phpunit": "^2.0.4",
-        "prism-php/prism": "^0.78.0",
+        "prism-php/prism": ">=v0.89.0 < v1.0",
         "rector/rector": "^2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "laravel/pint": "^1.14",
         "nette/php-generator": "^4.0",
         "nunomaduro/collision": "^7.10.0||^8.1.1",
-        "orchestra/testbench": "^8.22.0||^9.0.0||^10.0.0",
+        "orchestra/testbench": "^8.22.0||^9.0.0||^10.0.0||^11.0.0",
         "pestphp/pest": "^3.6.0||^4.0.0",
         "pestphp/pest-plugin-arch": "^3.0.0||^4.0.0",
         "pestphp/pest-plugin-laravel": "^3.0.0||^4.0.0",
@@ -43,7 +43,7 @@
         "phpstan/phpstan-deprecation-rules": "^2.0.1",
         "phpstan/phpstan-phpunit": "^2.0.4",
         "prism-php/prism": "^0.78.0",
-        "rector/rector": "2.*"
+        "rector/rector": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-dom": "*",
         "ext-simplexml": "*",
         "goetas-webservices/xsd-reader": "*",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "jms/serializer": "^3.14",
         "spatie/laravel-package-tools": "^1.16",
         "symfony/serializer": "^5.3 || ^6.0 || ^7.0 || ^8.0"

--- a/tests/Dtos/DtoTest.php
+++ b/tests/Dtos/DtoTest.php
@@ -52,7 +52,6 @@ test('dto values working', function () {
             return;
         }
 
-        /** @var ClassType $class */
         $class = ClassType::fromCode(File::get($file->getRealPath()));
 
         collect($class->getProperties())->each(function (Property $property) use ($class) {

--- a/tests/Services/DtoGeneratorTest.php
+++ b/tests/Services/DtoGeneratorTest.php
@@ -71,7 +71,6 @@ it('generates original DTOs with German names and correct namespace when transla
 
     $fileContents = file_get_contents($classFileName);
 
-    /** @var ClassType $generatedClass */
     $generatedClass = ClassType::fromCode($fileContents);
 
     // Class should use original German name

--- a/tests/Services/GeneratorHelper.php
+++ b/tests/Services/GeneratorHelper.php
@@ -46,7 +46,6 @@ trait GeneratorHelper
 
         assertFileExists($classFileName);
 
-        /** @var ClassType $generatedClass */
         $generatedClass = ClassType::fromCode(file_get_contents($classFileName));
 
         if ($docBlockComment !== '') {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: dependency constraint bumps and minor test-only cleanup, with no production logic changes.
> 
> **Overview**
> Adds Laravel 13 support by widening `illuminate/contracts` to include `^13.0` and updating dev tooling constraints (`orchestra/testbench` `^11`, `rector/rector` `^2.0`).
> 
> Cleans up a few tests by removing redundant `@var` annotations when parsing generated PHP code via `Nette\PhpGenerator\ClassType::fromCode()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44cac8f78a57a8f0fd3c1cb5d366243ac576dd04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->